### PR TITLE
Added function get_link_to

### DIFF
--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -35,6 +35,12 @@ class URLValue(StructValue):
         elif link_to == "custom_url":
             return self.get(link_to)
         return None
+    
+    def get_link_to(self):
+        """
+        Return link type for accessing in templates
+        """
+        return self.get("link_to")
 
 
 class LinkBlock(StructBlock):


### PR DESCRIPTION
Added function get_link_to for an easier access of this property in django templates. For example I want to generate a template for showing a icon depending on the type of link.