### PR TITLE
Format, Lint & version bump

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,0 @@
-[isort]
-combine_as_imports = true
-sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_django = django
-include_trailing_comma = false
-line_length = 99
-multi_line_output = 5
-skip_glob = */migrations/*.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.DEFAULT_GOAL := help
+PROJECT_DIR=wagtail_link_block
+
+help: ## Display this help dialog
+help: help-display
+
+format: ## Run this project's code formatters.
+format: black-format isort-format
+
+lint: ## Lint the project.
+lint: black-lint isort-lint flake8-lint
+
+# ISort
+isort-lint:
+	isort --check-only --diff ${PROJECT_DIR} setup.py
+
+isort-format:
+	isort ${PROJECT_DIR} setup.py
+
+# Flake8
+flake8-lint:
+	flake8 ${PROJECT_DIR} setup.py
+
+# Black
+black-lint:
+	black --check ${PROJECT_DIR} setup.py
+
+black-format:
+	black ${PROJECT_DIR} setup.py
+
+# Help
+help-display:
+	@awk '/^[\-[:alnum:]]*: ##/ { split($$0, x, "##"); printf "%20s%s\n", x[1], x[2]; }' $(MAKEFILE_LIST)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 99
+target-version = ['py35']
+
+[tool.isort]
+combine_as_imports = true
+sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']
+known_django = 'django'
+include_trailing_comma = true
+float_to_top = true
+force_grid_wrap = 0
+line_length = 99
+multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name="wagtail-link-block",
-    version="0.1.1",
+    version="0.1.2",
     description="Wagtail LinkBlock",
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=["Django>=1.11"],
     classifiers=[
         "Intended Audience :: Developers",
-       "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",

--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -3,17 +3,17 @@ The LinkBlock is not designed to be used on it's own - but as part of other bloc
 """
 from django.forms.utils import ErrorList
 
+from wagtail.admin.forms.choosers import URLOrAbsolutePathValidator
 from wagtail.core.blocks import (
     BooleanBlock,
+    CharBlock,
     ChoiceBlock,
     PageChooserBlock,
     StreamBlockValidationError,
     StructBlock,
     StructValue,
-    CharBlock,
 )
 from wagtail.documents.blocks import DocumentChooserBlock
-from wagtail.admin.forms.choosers import URLOrAbsolutePathValidator
 
 ##############################################################################
 # Component Parts - should not be used on their own - but as parts of other
@@ -35,7 +35,7 @@ class URLValue(StructValue):
         elif link_to == "custom_url":
             return self.get(link_to)
         return None
-    
+
     def get_link_to(self):
         """
         Return link type for accessing in templates
@@ -45,8 +45,8 @@ class URLValue(StructValue):
 
 class LinkBlock(StructBlock):
     """
-        A Link which can either be to a (off-site) URL, to a page in the site,
-        or to a document. Use this instead of URLBlock.
+    A Link which can either be to a (off-site) URL, to a page in the site,
+    or to a document. Use this instead of URLBlock.
     """
 
     link_to = ChoiceBlock(


### PR DESCRIPTION
## Description:

- Adds black / isort / flake8 linting & formatting to a basic Makefile
- Actually run the linting / formatting.  (not automated yet. Soon)
- Bumps the version minor number ( to include #2 )