### PR TITLE
Version bump to deploy i18n, and Makefile additional helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,24 @@ black-lint:
 black-format:
 	black ${PROJECT_DIR} setup.py
 
+build: ## Build the project ready for deployment to pypi
+build: dist
+
+dist: setup.py
+	python3 setup.py sdist bdist_wheel
+
+deploy-test: ## Build and upload the project to TestPyPI (sandbox)
+deploy-test: dist
+	@echo You will need to manually run:
+	@echo 'twine upload -r testpypi dist/*'
+
+deploy: ## Build and upload the project to PyPI
+deploy: dist
+	@echo You will need to manually run:
+	@echo 'twine upload dist/*'
+
+
+
 # Help
 help-display:
 	@awk '/^[\-[:alnum:]]*: ##/ { split($$0, x, "##"); printf "%20s%s\n", x[1], x[2]; }' $(MAKEFILE_LIST)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name="wagtail-link-block",
-    version="0.1.2",
+    version="0.1.3",
     description="Wagtail LinkBlock",
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Bump the version number to deploy #5 to pypi, and add some extra helpers to the Makefile to make consistent deployment easier to remember.