### PR TITLE
0.1.4 (bugfix for telepath streamfields)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(filename):
 
 setup(
     name="wagtail-link-block",
-    version="0.1.3",
+    version="0.1.4",
     description="Wagtail LinkBlock",
     long_description=read("README.rst"),
     long_description_content_type="text/x-rst",

--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -109,6 +109,6 @@ class LinkBlock(StructBlock):
                 errors[url_type] = ErrorList(["Enter a valid link type"])
 
         if errors:
-            raise StreamBlockValidationError(block_errors=errors)
+            raise StreamBlockValidationError(block_errors=errors, non_block_errors=ErrorList([]))
 
         return clean_values


### PR DESCRIPTION
1. Fixes a bug where on wagtail 2.15 (and probably earlier - from when telepath appeared) validationerrors inside streamfields are handled a bit differently.
2. Version bump.