### PR TITLE
added phone to link options

### DIFF
--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -40,6 +40,8 @@ class URLValue(StructValue):
             return "#" + self.get(link_to)
         elif link_to == "email":
             return "mailto:{}".format(self.get(link_to))
+        elif link_to == "phone":
+            return "tel:{}".format(self.get(link_to))
         return None
 
     def get_link_to(self):
@@ -62,6 +64,7 @@ class LinkBlock(StructBlock):
             ("custom_url", _("Custom URL")),
             ("email", _("Email")),
             ("anchor", _("Anchor")),
+            ("phone", _("Phone")),
         ],
         required=False,
         classname="link_choice_type_selector",
@@ -83,6 +86,13 @@ class LinkBlock(StructBlock):
         label=_("#"),
     )
     email = EmailBlock(required=False)
+    phone = CharBlock(
+        max_length=30,
+        required=False,
+        classname="phone_link",
+        label=_("Phone")
+    )
+
     new_window = BooleanBlock(
         label=_("Open in new window"), required=False, classname="new_window_toggle"
     )
@@ -111,6 +121,7 @@ class LinkBlock(StructBlock):
             "custom_url": "",
             "anchor": "",
             "email": "",
+            "phone": "",
         }
         url_type = clean_values.get("link_to")
 

--- a/wagtail_link_block/static/link_block/link_block.js
+++ b/wagtail_link_block/static/link_block/link_block.js
@@ -7,13 +7,13 @@
 
     function setRelatedFieldsVisibility(link_type_selector) {
         const value = link_type_selector.value;
-        const parent = link_type_selector.closest('.link_block');
-            page_link = parent.querySelector('.page_link_field');
-            file_link = parent.querySelector('.file_link_field');
-            custom_url_link = parent.querySelector('.custom_url_link_field');
-            anchor_link = parent.querySelector('.anchor_link_field');
-            new_window_toggle = parent.querySelector('.new_window_link_field');
-            email_address = parent.querySelector('.email_link_field');
+        const parent = link_type_selector.closest('.link_block'),
+            page_link = parent.querySelector('.page_link_field'),
+            file_link = parent.querySelector('.file_link_field'),
+            custom_url_link = parent.querySelector('.custom_url_link_field'),
+            anchor_link = parent.querySelector('.anchor_link_field'),
+            new_window_toggle = parent.querySelector('.new_window_link_field'),
+            email_address = parent.querySelector('.email_link_field'),
             phone_link = parent.querySelector('.phone_link_field');
 
         // first hide all

--- a/wagtail_link_block/static/link_block/link_block.js
+++ b/wagtail_link_block/static/link_block/link_block.js
@@ -7,14 +7,14 @@
 
     function setRelatedFieldsVisibility(link_type_selector) {
         const value = link_type_selector.value;
-        const parent = link_type_selector.closest('.link_block'),
-            page_link = parent.querySelector('.page_link_field'),
-            file_link = parent.querySelector('.file_link_field'),
-            custom_url_link = parent.querySelector('.custom_url_link_field'),
-            anchor_link = parent.querySelector('.anchor_link_field'),
-            new_window_toggle = parent.querySelector('.new_window_link_field'),
-            email_address = parent.querySelector('.email_link_field'),
-            phone_link = parent.querySelector('.phone_link_field')
+        const parent = link_type_selector.closest('.link_block');
+            page_link = parent.querySelector('.page_link_field');
+            file_link = parent.querySelector('.file_link_field');
+            custom_url_link = parent.querySelector('.custom_url_link_field');
+            anchor_link = parent.querySelector('.anchor_link_field');
+            new_window_toggle = parent.querySelector('.new_window_link_field');
+            email_address = parent.querySelector('.email_link_field');
+            phone_link = parent.querySelector('.phone_link_field');
 
         // first hide all
         page_link.classList.add('link-block__hidden');

--- a/wagtail_link_block/static/link_block/link_block.js
+++ b/wagtail_link_block/static/link_block/link_block.js
@@ -12,8 +12,9 @@
             file_link = parent.querySelector('.file_link_field'),
             custom_url_link = parent.querySelector('.custom_url_link_field'),
             anchor_link = parent.querySelector('.anchor_link_field'),
-            new_window_toggle = parent.querySelector('.new_window_link_field');
-            email_address = parent.querySelector('.email_link_field');
+            new_window_toggle = parent.querySelector('.new_window_link_field'),
+            email_address = parent.querySelector('.email_link_field'),
+            phone_link = parent.querySelector('.phone_link_field')
 
         // first hide all
         page_link.classList.add('link-block__hidden');
@@ -22,6 +23,7 @@
         anchor_link.classList.add('link-block__hidden');
         new_window_toggle.classList.add('link-block__hidden');
         email_address.classList.add('link-block__hidden');
+        phone_link.classList.add('link-block__hidden');
 
         // display the one
         if (value === 'page') {
@@ -37,6 +39,8 @@
             new_window_toggle.classList.remove('link-block__hidden');
         } else if (value === 'email') {
             email_address.classList.remove('link-block__hidden');
+        } else if (value === 'phone') {
+            phone_link.classList.remove('link-block__hidden');
         } else {
           // I don't know what to display here.
         }

--- a/wagtail_link_block/templates/wagtailadmin/block_forms/link_block.html
+++ b/wagtail_link_block/templates/wagtailadmin/block_forms/link_block.html
@@ -13,7 +13,7 @@
   {% for child in children.values %}
     <div class="field
                      {% if child.block.required %}required{% endif %}
-                     {% if child.block.name in 'page,file,custom_url,anchor,new_window,email' %}
+                     {% if child.block.name in 'page,file,custom_url,anchor,new_window,email,phone' %}
                        {{ child.block.name }}_link_field link-block__hidden
                      {% endif %}
                      ">


### PR DESCRIPTION
Added a phone link to the `LinkBlock` options. 

# To test
Go onto a project and `pip install -e git+https://github.com/developersociety/wagtail-link-block.git@ d30fadf80c2b2928908195103b42c788041af1fa#egg=wagtail_link_block`

Go to any page and try adding a CTA block, there should be an option for phone. Add a phone number. Save. Does the link appear as a number link.