### PR TITLE
Make link_to field required

### DIFF
--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -80,7 +80,7 @@ class LinkBlock(StructBlock):
             ("anchor", _("Anchor")),
             ("phone", _("Phone")),
         ],
-        required=False,
+        required=True,
         classname="link_choice_type_selector",
         label=_("Link to"),
     )


### PR DESCRIPTION
Make `link_to` field required. Currently it is not required, resulting in links to `None`. See issue #13.

This fix seems to work for me:
<img width="320" alt="afbeelding" src="https://user-images.githubusercontent.com/1089611/224953810-2d971ed4-34a5-493d-bdf5-a0a50b822ebe.png">
