### PR TITLE
Pass the 'required' option down to the link_to, and display correctly.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wagtail-link-block"
-version = "0.1.6"
+version = "1.1.7"
 description = "A Block for wagtail that lets users choose a Page/Document/URL/email/etc. as a link"
 authors = ["The Developer Society <studio@dev.ngo>"]
 readme = "README.rst"

--- a/wagtail_link_block/blocks.py
+++ b/wagtail_link_block/blocks.py
@@ -1,6 +1,8 @@
 """
 The LinkBlock is not designed to be used on it's own - but as part of other blocks.
 """
+from copy import deepcopy
+
 from django.forms.utils import ErrorList
 from django.utils.translation import gettext_lazy as _
 
@@ -113,6 +115,14 @@ class LinkBlock(StructBlock):
         form_classname = "link_block"
         form_template = "wagtailadmin/block_forms/link_block.html"
         template = "blocks/link_block.html"
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Make a deep copy of the link-to, as we need to pass the
+        # 'required' option down to it, and don't want to pollute
+        # the other LinkBlocks that are defined on other parent blocks.
+        self.child_blocks["link_to"] = deepcopy(self.child_blocks["link_to"])
+        self.child_blocks["link_to"].field.required = kwargs.get("required", False)
 
     def set_name(self, name):
         """

--- a/wagtail_link_block/templates/wagtailadmin/block_forms/link_block.html
+++ b/wagtail_link_block/templates/wagtailadmin/block_forms/link_block.html
@@ -18,7 +18,11 @@
                      {% endif %}
                      ">
       {% if child.block.label %}
-        <label class="field__label" {% if child.id_for_label %}for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}</label>
+        <label class="w-field__label" {% if child.id_for_label %}for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}
+          {% if child.block.required or child.block.name in 'page,file,custom_url,anchor,email,phone' %}
+            <span class="w-required-mark">*</span>
+          {% endif %}
+        </label>
       {% endif %}
       {{ child.render_form }}
     </div>


### PR DESCRIPTION
replaces: #16 

closes: #13 

----

Pass the 'required' kwarg option down to the `link_to` field, and display required field labels correctly (new wagtail stuff??)

---

# To test:

Load this version into a project:

```
pip install -e git+https://github.com/developersociety/wagtail-link-block.git@07c461bae6c35e875966dc26713537524a24014a#egg=wagtail_link_block
```

it should not require migrations.
Edit one block definition to add `required=True` - then check in the wagtail admin... that should now work correctly - but OTHER blocks using the link block should still be NOT required=True.

Now you should need to make migrations.