### PR TITLE
Checking Wagtail 6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ version = '1.1.7'
 description = 'A Block for Wagtail that lets users choose a Page/Document/URL/email/etc. as a link'
 readme = 'README.md'
 maintainers = [{ name = 'The Developer Society', email = 'studio@dev.ngo' }]
-requires-python = '>= 3.8'
+requires-python = '>= 3.9'
 dependencies = [
-    'Wagtail>=4.1',
+    'Wagtail>=5.2',
 ]
 classifiers = [
     'Intended Audience :: Developers',
@@ -14,15 +14,17 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Framework :: Django',
-    'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',
+    'Framework :: Django :: 5.1',
+    'Framework :: Wagtail',
+    'Framework :: Wagtail :: 5',
+    'Framework :: Wagtail :: 6',
 ]
 
 [project.urls]
@@ -37,7 +39,7 @@ include = ['wagtail_link_block*']
 
 [tool.ruff]
 line-length = 99
-target-version = 'py38'
+target-version = 'py39'
 
 [tool.ruff.lint]
 select = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,22 +2,20 @@
 env_list =
     check
     lint
-    py{38,39,310,311}-django3.2-wagtail4.1
-    py{38,39,310,311,312}-django{3.2,4.2}-wagtail5.2
-    py{38,39,310,311,312}-django4.2-wagtail6.1
-    py{310,311,312}-django5.0-wagtail6.1
+    py{39,310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
+    py{310,311,312}-django5.1-wagtail6.3
     coverage
 no_package = true
 
 [testenv]
 deps =
     -rrequirements/testing.txt
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
-    wagtail4.1: wagtail>=4.1,<4.2
+    django5.1: Django>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
 allowlist_externals = make
 commands = make test
 package = editable

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 env_list =
     check
     lint
-    py{39,310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
+    py39-django4.2-wagtail{5.2,6.2}
+    py{310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
     py{310,311,312}-django5.1-wagtail6.3
     coverage
 no_package = true


### PR DESCRIPTION
This pull request updates the project dependencies and testing configurations to ensure compatibility with newer versions of Python, Django, and Wagtail. The most important changes include updating the required Python version, updating the Wagtail and Django dependencies, and modifying the testing environment configurations.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R27): Updated the required Python version to `>= 3.9` and the Wagtail dependency to `>= 5.2`. Also updated the supported versions of Django and Wagtail in the classifiers section.

Testing configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R42): Changed the `target-version` for Ruff from `py38` to `py39`.
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L5-R19): Updated the testing environments to reflect the new supported versions of Python, Django, and Wagtail. Removed older versions and added new configurations for Django 5.1 and Wagtail 6.3.