### PR TITLE
Add Wagtail 6.4 and Python3.13 testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Framework :: Django',
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ env_list =
     check
     lint
     py39-django4.2-wagtail{5.2,6.2}
-    py{310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
-    py{310,311,312}-django5.1-wagtail6.3
+    py{310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3,6.4}
+    py{310,311,312}-django5.1-wagtail{6.3,6.4}
+    py313-django5.1-wagtail{6.3,6.4}
     coverage
 no_package = true
 
@@ -17,6 +18,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 allowlist_externals = make
 commands = make test
 package = editable


### PR DESCRIPTION
This pull request includes updates to the `pyproject.toml` and `tox.ini` files to add support for Python 3.13 and Wagtail 6.4.

Support for Python 3.13:

* Added 'Programming Language :: Python :: 3.13' to the classifiers list.

Support for Wagtail 6.4:

* Updated the `env_list` to include Wagtail 6.4 for Python 3.10, 3.11, 3.12, and 3.13.
* Added Wagtail 6.4 to the `deps` section to specify the version range.