### PR TITLE
Wagtail 7.0 maintenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Framework :: Django',
     'Framework :: Django :: 4.2',
-    'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
     'Framework :: Wagtail',
     'Framework :: Wagtail :: 5',
     'Framework :: Wagtail :: 6',
+    'Framework :: Wagtail :: 7',
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,8 @@
 env_list =
     check
     lint
-    py39-django4.2-wagtail{5.2,6.2}
-    py{310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3,6.4}
-    py{310,311,312}-django5.1-wagtail{6.3,6.4}
-    py313-django5.1-wagtail{6.3,6.4}
+    py{39,310,311,312}-django4.2-wagtail{5.2,6.3,6.4,7.0}
+    py{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
     coverage
 no_package = true
 
@@ -13,12 +11,12 @@ no_package = true
 deps =
     -rrequirements/testing.txt
     django4.2: Django>=4.2,<5.0
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 allowlist_externals = make
 commands = make test
 package = editable


### PR DESCRIPTION
This pull request updates the project to test newer versions of Django and Wagtail while removing test for older versions.

### Updates to supported versions:

* Added testing for Django 5.2 and Wagtail 7, while removing support for Django 5.0.
* Updated the test matrix to include Django 5.2 and Wagtail 7.0, and removed configurations for Django 5.0 and EOL Wagtail versions like 6.2.