### PR TITLE
Wagtail 7.1 maintenance

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 env_list =
     check
     lint
-    py{39,310,311,312}-django4.2-wagtail{5.2,6.3,6.4,7.0}
-    py{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
+    py{39,310,311,312}-django4.2-wagtail{5.2,6.3,6.4,7.0,7.1}
+    py{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,6.4,7.0,7.1}
     coverage
 no_package = true
 
@@ -17,6 +17,7 @@ deps =
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.1: wagtail>=7.1,<7.2
 allowlist_externals = make
 commands = make test
 package = editable


### PR DESCRIPTION
This pull request updates the test matrix in `tox.ini` to add support for Wagtail 7.1

**Test matrix updates:**

* Added `wagtail7.1` to the `env_list` for both Django 4.2 and Django 5.1/5.2 environments, allowing tests to run against Wagtail 7.1.

**Dependency management:**

* Defined a new dependency group for `wagtail7.1` to ensure the correct Wagtail version is installed during testing (`wagtail>=7.1,<7.2`).