### PR TITLE
Remove link_block.html template

### DIFF
--- a/wagtail_link_block/templates/blocks/link_block.html
+++ b/wagtail_link_block/templates/blocks/link_block.html
@@ -1,1 +1,0 @@
-<a href="{{ self.link.get_url }}" {% if self.link.new_window %}target="_blank"{% endif %}>{{ self.text }}</a>


### PR DESCRIPTION
I added this back in #20 - to improve testing, however as it's in the package templates directory - it would be distributed as part of the package.

So, dropping it for now.

We'll probably need something back at a later date, but let's get a bugfix release out first.